### PR TITLE
reset shared pointer when closing ofxFlyCapture object

### DIFF
--- a/src/ofxFlyCapture.cpp
+++ b/src/ofxFlyCapture.cpp
@@ -154,6 +154,7 @@ void ofxFlyCapture::close() {
 	if (camera != nullptr) {
 		camera->Disconnect();
 		camera.reset();
+		bGrabberInitied = false;
 	}
 }
 

--- a/src/ofxFlyCapture.cpp
+++ b/src/ofxFlyCapture.cpp
@@ -153,6 +153,7 @@ bool ofxFlyCapture::isFrameNew() const {
 void ofxFlyCapture::close() {
 	if (camera != nullptr) {
 		camera->Disconnect();
+		camera.reset();
 	}
 }
 


### PR DESCRIPTION
Currently, an ofxFlyCapture object can't be re-initialized. For example, if the feed drops out then the camera cannot be turned off then back on to re-establish the feed. This patch adds that functionality.